### PR TITLE
Use AppModule and unreleased ui-router beta.2 code

### DIFF
--- a/src/adapter.js
+++ b/src/adapter.js
@@ -1,12 +1,15 @@
 import { UpgradeAdapter } from '@angular/upgrade';
 import { uiRouterNgUpgrade } from 'ui-router-ng1-to-ng2';
+import { UIROUTER_DIRECTIVES, UIView } from 'ui-router-ng2';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { AdminModule } from './app/admin/admin';
+import { UIRouterModule } from "./uirouter_module";
 
 const Ng2AppModule =
   NgModule({
     declarations: [],
-    imports: [BrowserModule],
+    imports: [BrowserModule, UIRouterModule, AdminModule],
     providers: []
   }).Class({
     constructor: function Ng2AppModule() {},

--- a/src/app/admin/admin.js
+++ b/src/app/admin/admin.js
@@ -1,18 +1,23 @@
 import { Component, NgModule } from '@angular/core';
-import { UIROUTER_DIRECTIVES, StateService } from 'ui-router-ng2';
+import { StateService } from 'ui-router-ng2';
+import { UIRouterModule } from "../../uirouter_module"; // when beta.2: from "ui-router-ng2"
 
 //@NgModule({ imports: [ AppModule ] })
 @Component({
   selector: 'admin',
-  directives: [UIROUTER_DIRECTIVES],
   template: `
     <h1>I'm a ng2 page</h1>
     <a uiSref="login">Goto ng1 page</a>
   `
 })
-export class AppComponent {
+export class AppComponent { }
 
-}
+@NgModule({
+  imports: [UIRouterModule],
+  declarations: [AppComponent],
+  entryComponents: [AppComponent]
+}) 
+export class AdminModule {}
 
 export default angular
   .module('admin', [])

--- a/src/uirouter_module.js
+++ b/src/uirouter_module.js
@@ -1,0 +1,11 @@
+import { UIROUTER_DIRECTIVES, UIView } from 'ui-router-ng2';
+import { NgModule } from '@angular/core';
+
+export const UIRouterModule = 
+  NgModule({
+    declarations: [UIROUTER_DIRECTIVES],
+    exports: [UIROUTER_DIRECTIVES],
+    entryComponents: [UIView]
+  }).Class({
+    constructor: function UIRouterModule() {}
+  });


### PR DESCRIPTION
You need to build ui-router from master and COPY it into your node_modules
I don't know why `npm link` doesn't work, but webpack bundles ui-router code TWICE if you use `npm link`.

from ui-router directory:

```
npm install
node ./scripts/package.js ng2
cp -Rp build_packages/ng2 $SOMEDIR/ng1-ng2-webpack-lazy-uirouter/node_modules/ui-router-ng2
```

Build the ui-router-ng2 package
Copy it to your `node_modules` directory as `ui-router-ng2`
